### PR TITLE
Hacky fix for speed options

### DIFF
--- a/src/js/more-speed-options.js
+++ b/src/js/more-speed-options.js
@@ -9,37 +9,39 @@
   let selectedIndex = 2
   
   // Whenever user clicks on settings icon, this listener is triggered
-  const settingsMenuElement = document.getElementsByClassName('video-menu settings-menu')[0]
-  settingsMenuElement.addEventListener('DOMNodeInserted', (evt) => {
-  
-    // Only add speed options if new element is menu settings popup
-    if (evt.target.className.startsWith('menu settings')) {
-      // Get the element which holds the speed options
-      const speedSelectElement = document.getElementById('speed-select')
-  
-      // Now add the various speed options
-      for (speed of SPEED_OPTIONS) {
-        const option = document.createElement('option')
-        option.value = "" + speed
-        option.innerHTML = speed
-        speedSelectElement.appendChild(option)
-      }
-  
-  
-      /// Since the custom speed options don't exist each time we open the menu, the selectedIndex
-      /// of the <select> element is too large for the list and so it is reset back to 0.
-      /// Thus the code below will 'reload' the previously selected option
-  
-      // Store the selected option whenever it changes
-      speedSelectElement.onchange = evt => {
-        selectedIndex = evt.target.selectedIndex
-      }
-  
-      // Select whichever speed was previous selected
-      speedSelectElement.selectedIndex = selectedIndex
-  
+  const wait = setInterval(function() {
+    if (document.getElementsByClassName('video-menu settings-menu')) {
+      clearInterval(wait);
+      
+      document.getElementsByClassName('video-menu settings-menu')[0].addEventListener('DOMNodeInserted', (evt) => {
+        // Only add speed options if new element is menu settings popup
+        if (evt.target.className.startsWith('menu settings')) {
+          // Get the element which holds the speed options
+          const speedSelectElement = document.getElementById('speed-select')
+      
+          // Now add the various speed options
+          for (speed of SPEED_OPTIONS) {
+            const option = document.createElement('option')
+            option.value = "" + speed
+            option.innerHTML = speed
+            speedSelectElement.appendChild(option)
+          }
+      
+      
+          /// Since the custom speed options don't exist each time we open the menu, the selectedIndex
+          /// of the <select> element is too large for the list and so it is reset back to 0.
+          /// Thus the code below will 'reload' the previously selected option
+      
+          // Store the selected option whenever it changes
+          speedSelectElement.onchange = evt => {
+            selectedIndex = evt.target.selectedIndex
+          }
+      
+          // Select whichever speed was previous selected
+          speedSelectElement.selectedIndex = selectedIndex
+      
+        }
+      })  
     }
-  
-  })  
-
+  }, 500)
 })()


### PR DESCRIPTION
`video-menu settings-menu` isn't necessarily loaded at `document_end` anymore, use setInterval to manually check for element load. There's probably a cleaner event-based solution, but this was a few minutes to write.